### PR TITLE
Fix version dropdown on mobile

### DIFF
--- a/docs/javascripts/extra.js
+++ b/docs/javascripts/extra.js
@@ -77,6 +77,39 @@ function populateNav() {
   `;
 }
 
+function stopFocusOnVersions() {
+  const versionItems = document.querySelectorAll('.md-version__link');
+  for (let i = 0; i < versionItems.length; i++) {
+    versionItems[i].addEventListener('focus', (e) => {
+      versionItems[i].blur();
+    });
+  }
+}
+
+waitForElm('.md-version').then(() => {
+  stopFocusOnVersions();
+});
+
+function waitForElm(selector) {
+  return new Promise(resolve => {
+    if (document.querySelector(selector)) {
+      return resolve(document.querySelector(selector));
+    }
+
+    const observer = new MutationObserver(mutations => {
+      if (document.querySelector(selector)) {
+        observer.disconnect();
+        resolve(document.querySelector(selector));
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  });
+}
+
 function narrowScreen() {
   return document.querySelector('.top-right-links .search-container').offsetParent;
 }


### PR DESCRIPTION
Fixes an issue with the version dropdown on mobile/tablet. It was difficult to scroll through the list of versions without selecting a version accidentally.

This happened because scrolling by touch could cause version items to receive 'focus', which would caused them to be selected. This PR stops the version items from receiving focus.

Technical note: the version selector is produced by mkdocs material using typescript, so a javascript function was added that waits for the version selector element to be created before adding event listeners that fix the focusing issue.