### PR TITLE
Template Fixes & Improvements

### DIFF
--- a/partials/warehouse/templates/container-cruncher-large.yml
+++ b/partials/warehouse/templates/container-cruncher-large.yml
@@ -102,16 +102,6 @@ resources:
           port_range_max: 5911
           protocol: tcp
           remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: tcp
-          remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: udp
-          remote_ip_prefix: 0.0.0.0/0
 
   gateway-pri-port:
     type: OS::Neutron::Port
@@ -248,7 +238,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -300,7 +289,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -352,7 +340,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -404,7 +391,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -456,7 +442,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -508,7 +493,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -560,7 +544,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -612,7 +595,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -664,7 +646,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -716,7 +697,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root

--- a/partials/warehouse/templates/container-cruncher-medium.yml
+++ b/partials/warehouse/templates/container-cruncher-medium.yml
@@ -102,16 +102,6 @@ resources:
           port_range_max: 5911
           protocol: tcp
           remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: tcp
-          remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: udp
-          remote_ip_prefix: 0.0.0.0/0
 
   gateway-pri-port:
     type: OS::Neutron::Port
@@ -248,7 +238,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -300,7 +289,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -352,7 +340,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -404,7 +391,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -456,7 +442,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root

--- a/partials/warehouse/templates/container-cruncher-small.yml
+++ b/partials/warehouse/templates/container-cruncher-small.yml
@@ -102,16 +102,6 @@ resources:
           port_range_max: 5911
           protocol: tcp
           remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: tcp
-          remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: udp
-          remote_ip_prefix: 0.0.0.0/0
 
   gateway-pri-port:
     type: OS::Neutron::Port
@@ -241,7 +231,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -293,7 +282,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root

--- a/partials/warehouse/templates/jupyterlab-jumpstart.yml
+++ b/partials/warehouse/templates/jupyterlab-jumpstart.yml
@@ -94,16 +94,6 @@ resources:
           port_range_max: 5911
           protocol: tcp
           remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: tcp
-          remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: udp
-          remote_ip_prefix: 0.0.0.0/0
 
   gateway-pri-port:
     type: OS::Neutron::Port

--- a/partials/warehouse/templates/slurm-team-edition.yml
+++ b/partials/warehouse/templates/slurm-team-edition.yml
@@ -106,16 +106,6 @@ resources:
           port_range_max: 5911
           protocol: tcp
           remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: tcp
-          remote_ip_prefix: 0.0.0.0/0
-        - direction: ingress
-          port_range_min: 8888
-          port_range_max: 8888
-          protocol: udp
-          remote_ip_prefix: 0.0.0.0/0
 
   gateway-pri-port:
     type: OS::Neutron::Port
@@ -157,6 +147,7 @@ resources:
                   SHAREPUBKEY=true
                   AUTOPARSEMATCH=$clustername
                   PROFILE_ANSWERS='{ "cluster_type": "openflight-slurm-multinode", "cluster_name": "$clustername", "nfs_server": "gateway1", "slurm_server": "gateway1", "ipa_use": "true", "ipa_server": "infra01", "ipa_domain": "$clustername.alces.network" }'
+                  AUTOAPPLY="node: compute"
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -188,9 +179,12 @@ resources:
                     sleep 5
                   done
                   /opt/flight/bin/flight profile apply infra01 ipa --wait
-                  /opt/flight/bin/flight profile apply gateway1 login 
-                  COMPUTE_NODES="$(/opt/flight/bin/flight hunter list --plain |awk '{print $5}' |grep '^node' |paste -s -d,)"
-                  /opt/flight/bin/flight profile apply $COMPUTE_NODES compute
+                  /opt/flight/bin/flight profile apply gateway1 login --wait
+                  # Ensure write access to user NFS mounts for cluster users
+                  chgrp cluster-users /opt/{apps,data}
+                  chmod 775 /opt/{apps,data}
+                  # Make Flight Silo use /opt/apps/
+                  pdsh -g all "sed -i 's,^software_dir:.*,software_dir: /opt/apps,g' /opt/flight/opt/silo/etc/config.yml"
                 path: /var/lib/firstrun/scripts/99-apply-identities.bash
                 permissions: '0600'
                 owner: root:root
@@ -311,7 +305,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -363,7 +356,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -415,7 +407,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -467,7 +458,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root
@@ -519,7 +509,6 @@ resources:
             write_files:
               - content: |
                   SERVER=$gateway-pri-ip
-                  PREFIX=node
                 path: /opt/flight/cloudinit.in
                 permissions: '0600'
                 owner: root:root


### PR DESCRIPTION
- Remove the unnecessary Port 8888 rules (flight hunter uses this port and it really should only work within the cluster subnet, we probably don't want external things to be able to send hunter stuff by default) 
- Remove the node label prefix from compute nodes (if nodes come up in a different order to their naming then the labels can get very misleading and, ultimately, cause all sorts of DNS issues)
- Improved setup and defaults for SLURM Team Edition