### PR TITLE
Stop clouds getting too big at large screen widths

### DIFF
--- a/docs/stylesheets/_footer.css
+++ b/docs/stylesheets/_footer.css
@@ -7,7 +7,7 @@
 }
 
 .cloud {
-    width: 20vw;
+    width: 17rem;
     min-width: 17rem;
     position: absolute;
     bottom: 0;
@@ -16,7 +16,7 @@
 }
 
 .parting-cloud {
-    width: 35vw;
+    width: min(35vw, 32rem);
 }
 
 #cloud-l {


### PR DESCRIPTION
The width of the cloud images in the footer was set as a fraction of browser window width. This meant that they got too big at large screen widths, which could cause them to cover content at the bottom of the page. This PR stops the clouds from getting big enough to obstruct page contents.